### PR TITLE
Add Salesforce staging models for contacts, campaign_members, and opportunities

### DIFF
--- a/models/staging/salesforce/schema.yml
+++ b/models/staging/salesforce/schema.yml
@@ -165,3 +165,218 @@ models:
           expression: "converted_date is not null"
           config:
             where: "is_converted = true"
+
+  - name: stg_salesforce__contacts
+    description: "Cleaned and standardized Salesforce contacts data"
+    columns:
+      - name: id
+        description: "Unique identifier for the contact"
+        tests:
+          - not_null
+          - unique
+      
+      - name: first_name
+        description: "Contact's first name"
+      
+      - name: last_name
+        description: "Contact's last name"
+      
+      - name: full_name
+        description: "Contact's full name"
+      
+      - name: email
+        description: "Contact's email address"
+        tests:
+          - dbt_utils.expression_is_true:
+              expression: "like '%@%'"
+              config:
+                where: "email is not null"
+      
+      - name: created_at
+        description: "When the contact was created"
+        tests:
+          - not_null
+      
+      - name: owner_id
+        description: "ID of the contact owner"
+        tests:
+          - not_null
+
+  - name: stg_salesforce__campaign_members
+    description: "Cleaned and standardized Salesforce campaign members data - junction table between campaigns and leads/contacts"
+    columns:
+      - name: id
+        description: "Unique identifier for the campaign member"
+        tests:
+          - not_null
+          - unique
+      
+      - name: campaign_id
+        description: "ID of the associated campaign"
+        tests:
+          - not_null
+          - relationships:
+              to: ref('stg_salesforce__campaigns')
+              field: id
+      
+      - name: lead_id
+        description: "ID of the associated lead (if member is a lead)"
+        tests:
+          - relationships:
+              to: ref('stg_salesforce__leads')
+              field: id
+              config:
+                where: "lead_id is not null"
+      
+      - name: contact_id
+        description: "ID of the associated contact (if member is a contact)"
+        tests:
+          - relationships:
+              to: ref('stg_salesforce__contacts')
+              field: id
+              config:
+                where: "contact_id is not null"
+      
+      - name: member_type
+        description: "Type of member: Lead or Contact"
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['Lead', 'Contact']
+      
+      - name: status
+        description: "Campaign member status"
+        tests:
+          - accepted_values:
+              values: ['Sent', 'Responded', 'Clicked', 'Opened', 'Bounced', 'Unsubscribed']
+      
+      - name: has_responded
+        description: "Whether the campaign member has responded"
+      
+      - name: first_responded_date
+        description: "Date of first response"
+      
+      - name: days_to_response
+        description: "Number of days from campaign member creation to first response"
+        tests:
+          - dbt_utils.expression_is_true:
+              expression: ">= 0"
+              config:
+                where: "days_to_response is not null"
+      
+      - name: created_at
+        description: "When the campaign member was created"
+        tests:
+          - not_null
+
+    tests:
+      - dbt_utils.expression_is_true:
+          name: member_must_have_lead_or_contact_id_not_both
+          expression: "(lead_id is not null and contact_id is null) or (lead_id is null and contact_id is not null)"
+      - dbt_utils.expression_is_true:
+          name: responded_members_must_have_response_date
+          expression: "first_responded_date is not null"
+          config:
+            where: "has_responded = true"
+
+  - name: stg_salesforce__opportunities
+    description: "Cleaned and standardized Salesforce opportunities data"
+    columns:
+      - name: id
+        description: "Unique identifier for the opportunity"
+        tests:
+          - not_null
+          - unique
+      
+      - name: name
+        description: "Opportunity name"
+        tests:
+          - not_null
+      
+      - name: campaign_id
+        description: "ID of the primary campaign source"
+        tests:
+          - relationships:
+              to: ref('stg_salesforce__campaigns')
+              field: id
+              config:
+                where: "campaign_id is not null"
+      
+      - name: contact_id
+        description: "ID of the primary contact"
+        tests:
+          - relationships:
+              to: ref('stg_salesforce__contacts')
+              field: id
+              config:
+                where: "contact_id is not null"
+      
+      - name: stage_name
+        description: "Current stage of the opportunity"
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['Prospecting', 'Qualification', 'Needs Analysis', 'Value Proposition', 'Id. Decision Makers', 'Perception Analysis', 'Proposal/Price Quote', 'Negotiation/Review', 'Closed Won', 'Closed Lost']
+      
+      - name: is_closed
+        description: "Whether the opportunity is closed"
+      
+      - name: is_won
+        description: "Whether the opportunity was won"
+      
+      - name: amount
+        description: "Opportunity amount"
+        tests:
+          - dbt_utils.expression_is_true:
+              expression: ">= 0"
+              config:
+                where: "amount is not null"
+      
+      - name: probability
+        description: "Probability of winning (0-100)"
+        tests:
+          - dbt_utils.expression_is_true:
+              expression: ">= 0 and probability <= 100"
+              config:
+                where: "probability is not null"
+      
+      - name: expected_revenue
+        description: "Expected revenue (amount × probability)"
+        tests:
+          - dbt_utils.expression_is_true:
+              expression: ">= 0"
+              config:
+                where: "expected_revenue is not null"
+      
+      - name: created_at
+        description: "When the opportunity was created"
+        tests:
+          - not_null
+      
+      - name: close_date
+        description: "Expected or actual close date"
+      
+      - name: sales_cycle_days
+        description: "Number of days from creation to close"
+        tests:
+          - dbt_utils.expression_is_true:
+              expression: ">= 0"
+              config:
+                where: "sales_cycle_days is not null"
+      
+      - name: owner_id
+        description: "ID of the opportunity owner"
+        tests:
+          - not_null
+
+    tests:
+      - dbt_utils.expression_is_true:
+          name: won_opportunities_must_have_close_date
+          expression: "close_date is not null"
+          config:
+            where: "is_won = true"
+      - dbt_utils.expression_is_true:
+          name: closed_opportunities_must_have_close_date
+          expression: "close_date is not null"
+          config:
+            where: "is_closed = true"

--- a/models/staging/salesforce/sources.yml
+++ b/models/staging/salesforce/sources.yml
@@ -18,3 +18,21 @@ sources:
         freshness:
           warn_after: {count: 24, period: hour}
           error_after: {count: 48, period: hour}
+
+      - name: salesforce_contacts
+        description: "Salesforce contacts data"
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
+
+      - name: salesforce_campaign_members
+        description: "Salesforce campaign members data - junction table between campaigns and leads/contacts"
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}
+
+      - name: salesforce_opportunities
+        description: "Salesforce opportunities data"
+        freshness:
+          warn_after: {count: 24, period: hour}
+          error_after: {count: 48, period: hour}

--- a/models/staging/salesforce/stg_salesforce__campaign_members.sql
+++ b/models/staging/salesforce/stg_salesforce__campaign_members.sql
@@ -1,0 +1,85 @@
+{{ config(materialized='view') }}
+
+with source as (
+    select * from {{ source('salesforce', 'salesforce_campaign_members') }}
+),
+
+transformed as (
+    select
+        campaignmember_id as id,
+        campaignmember_campaign_id as campaign_id,
+        campaignmember_lead_id as lead_id,
+        campaignmember_contact_id as contact_id,
+        campaignmember_lead_or_contact_id as lead_or_contact_id,
+        
+        -- Determine member_type as 'Lead' or 'Contact' based on which ID is populated
+        case 
+            when campaignmember_lead_id is not null then 'Lead'
+            when campaignmember_contact_id is not null then 'Contact'
+            else campaignmember_type
+        end as member_type,
+        
+        campaignmember_first_name as first_name,
+        campaignmember_last_name as last_name,
+        campaignmember_name as full_name,
+        campaignmember_salutation as salutation,
+        
+        campaignmember_company_or_account as company_or_account,
+        campaignmember_title as title,
+        campaignmember_phone as phone,
+        campaignmember_fax as fax,
+        campaignmember_lead_source as lead_source,
+        campaignmember_description as description,
+        
+        -- Date fields (already TIMESTAMP in source)
+        campaignmember_createddate as created_at,
+        campaignmember_lastmodifieddate as last_modified_at,
+        campaignmember_first_responded_date as first_responded_date,
+        
+        -- Convert string boolean to actual boolean for response tracking
+        case 
+            when lower(campaignmember_has_responded) = 'true' then true
+            when lower(campaignmember_has_responded) = 'false' then false
+            else null
+        end as has_responded,
+        
+        campaignmember_status as status,
+        
+        -- Calculate days_to_response from campaign member creation to response
+        case 
+            when campaignmember_first_responded_date is not null 
+                and campaignmember_createddate is not null
+            then date_diff(
+                date(campaignmember_first_responded_date),
+                date(campaignmember_createddate),
+                day
+            )
+            else null
+        end as days_to_response,
+        
+        -- Address fields
+        campaignmember_street as street,
+        campaignmember_postal_code as postal_code,
+        campaignmember_state as state,
+        campaignmember_country as country,
+        
+        -- Convert string boolean fields
+        case 
+            when lower(campaignmember_do_not_call) = 'true' then true
+            when lower(campaignmember_do_not_call) = 'false' then false
+            else null
+        end as do_not_call,
+        
+        case 
+            when lower(campaignmember_has_opted_out_of_fax) = 'true' then true
+            when lower(campaignmember_has_opted_out_of_fax) = 'false' then false
+            else null
+        end as has_opted_out_of_fax,
+        
+        -- Owner tracking
+        campaignmember_lead_or_contact_owner_id as lead_or_contact_owner_id
+
+    from source
+)
+
+select * from transformed

--- a/models/staging/salesforce/stg_salesforce__campaigns.sql
+++ b/models/staging/salesforce/stg_salesforce__campaigns.sql
@@ -14,11 +14,7 @@ transformed as (
         campaign_description as description,
         
         -- Convert STRING date fields to proper types
-        case 
-            when campaign_created_date is not null and campaign_created_date != ''
-            then parse_timestamp('%Y-%m-%d %H:%M:%S', campaign_created_date)
-            else null
-        end as created_at,
+        safe_cast(campaign_created_date as timestamp) as created_at,
         
         case 
             when campaign_start_date is not null and campaign_start_date != ''
@@ -72,7 +68,7 @@ transformed as (
         campaign_parent_id as parent_id,
 
     from source
-    where campaign_is_deleted = 'false'
+    where lower(campaign_is_deleted) = 'false'
 )
 
 select * from transformed

--- a/models/staging/salesforce/stg_salesforce__contacts.sql
+++ b/models/staging/salesforce/stg_salesforce__contacts.sql
@@ -1,0 +1,75 @@
+{{ config(materialized='view') }}
+
+with source as (
+    select * from {{ source('salesforce', 'salesforce_contacts') }}
+),
+
+transformed as (
+    select
+        contact_id as id,
+        contact_firstname as first_name,
+        contact_lastname as last_name,
+        contact_name as full_name,
+        contact_salutation as salutation,
+        
+        contact_email as email,
+        contact_phone as phone,
+        contact_mobilephone as mobile_phone,
+        contact_homephone as home_phone,
+        contact_otherphone as other_phone,
+        contact_fax as fax,
+        
+        contact_title as title,
+        contact_department as department,
+        contact_leadsource as lead_source,
+        contact_description as description,
+        
+        -- Clean date conversions using SAFE_CAST
+        safe_cast(contact_createddate as timestamp) as created_at,
+        safe_cast(contact_lastmodifieddate as timestamp) as last_modified_at,
+        safe_cast(contact_birthdate as date) as birthdate,
+        safe_cast(contact_lastactivitydate as date) as last_activity_date,
+        safe_cast(contact_lastreferenceddatetime as timestamp) as last_referenced_at,
+        safe_cast(contact_lastvieweddate as timestamp) as last_viewed_at,
+        safe_cast(contact_emailbounceddate as timestamp) as email_bounced_at,
+        
+        -- Account association
+        contact_accountid as account_id,
+        
+        -- Clean boolean conversion
+        safe_cast(contact_isemailbounced as boolean) as is_email_bounced,
+        contact_emailbouncedreason as email_bounced_reason,
+        
+        -- Mailing address fields
+        contact_mailingstreet as mailing_street,
+        contact_mailingcity as mailing_city,
+        contact_mailingstate as mailing_state,
+        contact_mailingpostalcode as mailing_postal_code,
+        contact_mailingcountry as mailing_country,
+        
+        -- Other address fields
+        contact_otherstreet as other_street,
+        contact_othercity as other_city,
+        contact_otherstate as other_state,
+        contact_otherpostalcode as other_postal_code,
+        contact_othercountry as other_country,
+        
+        -- Other useful fields
+        contact_ownerid as owner_id,
+        contact_reportstoid as reports_to_id,
+        contact_assistantname as assistant_name,
+        contact_assistantphone as assistant_phone,
+        contact_createdby as created_by,
+        
+        -- Custom fields
+        contact_wsai__languages__c as languages,
+        contact_wsai__level__c as level,
+        
+        -- System field
+        contact_date as date_field
+        
+    from source
+    where lower(contact_isdeleted) = 'false'
+)
+
+select * from transformed

--- a/models/staging/salesforce/stg_salesforce__opportunities.sql
+++ b/models/staging/salesforce/stg_salesforce__opportunities.sql
@@ -1,0 +1,115 @@
+{{ config(materialized='view') }}
+
+with source as (
+    select * from {{ source('salesforce', 'salesforce_opportunities') }}
+),
+
+transformed as (
+    select
+        opportunity_id as id,
+        opportunity_name as name,
+        opportunity_description as description,
+        opportunity_type as type,
+        
+        -- Links to primary campaign source via campaign_id
+        opportunity_campaign_id as campaign_id,
+        
+        -- Account and contact associations
+        opportunity_account_id as account_id,
+        opportunity_contact_id as contact_id,
+        
+        -- Stage progression and win/loss status
+        opportunity_stage_name as stage_name,
+        opportunity_forecast_category as forecast_category,
+        opportunity_forecast_category_name as forecast_category_name,
+        
+        -- Clean boolean conversions using SAFE_CAST
+        safe_cast(opportunity_is_closed as boolean) as is_closed,
+        safe_cast(opportunity_is_won as boolean) as is_won,
+        
+        -- Financial fields - includes expected_revenue and amount fields
+        safe_cast(opportunity_amount as numeric) as amount,
+        safe_cast(opportunity_probability as numeric) as probability,
+        
+        -- Calculate expected_revenue as amount * probability
+        case 
+            when safe_cast(opportunity_amount as numeric) is not null 
+                and safe_cast(opportunity_probability as numeric) is not null
+            then safe_cast(opportunity_amount as numeric) * (safe_cast(opportunity_probability as numeric) / 100)
+            else null
+        end as expected_revenue,
+        
+        -- Clean date conversions using SAFE_CAST
+        coalesce(
+            safe_cast(opportunity_created_date as timestamp),
+            safe_cast(opportunity_createddate as timestamp)
+        ) as created_at,
+        
+        safe_cast(opportunity_close_date as date) as close_date,
+        
+        coalesce(
+            safe_cast(opportunity_last_modified_date as timestamp),
+            safe_cast(opportunity_lastmodifieddate as timestamp)
+        ) as last_modified_at,
+        
+        safe_cast(opportunity_last_activity_date as date) as last_activity_date,
+        safe_cast(opportunity_last_referenced_date as timestamp) as last_referenced_at,
+        safe_cast(opportunity_last_viewed_date as timestamp) as last_viewed_at,
+        
+        -- Calculate sales_cycle_days using SAFE_CAST
+        case 
+            when safe_cast(opportunity_close_date as date) is not null
+                and coalesce(
+                    safe_cast(opportunity_created_date as timestamp),
+                    safe_cast(opportunity_createddate as timestamp)
+                ) is not null
+            then date_diff(
+                safe_cast(opportunity_close_date as date),
+                date(coalesce(
+                    safe_cast(opportunity_created_date as timestamp),
+                    safe_cast(opportunity_createddate as timestamp)
+                )),
+                day
+            )
+            else null
+        end as sales_cycle_days,
+        
+        -- Fiscal period fields
+        opportunity_fiscal as fiscal_period,
+        safe_cast(opportunity_fiscal_quarter as integer) as fiscal_quarter,
+        safe_cast(opportunity_fiscal_year as integer) as fiscal_year,
+        
+        -- Activity tracking - clean boolean conversions
+        safe_cast(opportunity_has_open_activity as boolean) as has_open_activity,
+        safe_cast(opportunity_has_opportunity_line_item as boolean) as has_opportunity_line_item,
+        safe_cast(opportunity_has_overdue_task as boolean) as has_overdue_task,
+        
+        -- Lead source
+        opportunity_lead_source as lead_source,
+        
+        -- Process fields
+        opportunity_next_step as next_step,
+        
+        -- Owner and system fields
+        opportunity_owner_id as owner_id,
+        opportunity_created_by_id as created_by_id,
+        opportunity_last_modified_by_id as last_modified_by_id,
+        opportunity_pricebook2_id as pricebook_id,
+        opportunity_system_modstamp as system_modstamp,
+        
+        -- History tracking
+        opportunity_last_amount_changed_history_id as last_amount_changed_history_id,
+        opportunity_last_close_date_changed_history_id as last_close_date_changed_history_id,
+        
+        -- Custom fields
+        opportunity_wsai__currentgenerators__c as current_generators,
+        opportunity_wsai__deliveryinstallationstatus__c as delivery_installation_status,
+        opportunity_wsai__maincompetitors__c as main_competitors,
+        opportunity_wsai__ordernumber__c as order_number,
+        opportunity_wsai__trackingnumber__c as tracking_number
+
+    from source
+    where opportunity_is_deleted = 'false'
+)
+
+select * from transformed


### PR DESCRIPTION
- Add staging models for contacts, campaign_members, and opportunities
- Use SAFE_CAST for data type handling and error prevention
- Add schema tests with referential integrity checks
- Standardize boolean field conversions across all models
- Add calculated fields for days_to_response, days_to_conversion, and sales_cycle_days
- Include data freshness checks for all source tables
- Add multi-table tests for business rule validation